### PR TITLE
Fix HDR playback on iOS / tvOS with current MPV (0.33.0)

### DIFF
--- a/video/out/opengl/hwdec_ios.m
+++ b/video/out/opengl/hwdec_ios.m
@@ -143,7 +143,7 @@ static int mapper_init(struct ra_hwdec_mapper *mapper)
 
     for (int n = 0; n < p->desc.num_planes; n++) {
         p->desc.planes[n] = find_la_variant(mapper->ra, p->desc.planes[n]);
-        if (!p->desc.planes[n] || p->desc.planes[n]->ctype != RA_CTYPE_UNORM) {
+        if (!p->desc.planes[n]) {
             MP_ERR(mapper, "Format unsupported.\n");
             return -1;
         }


### PR DESCRIPTION
If I'm honest, this is a bit of a blind fix, as I don't really know enough to fully understand what I'm doing.

When bumping from 0.28 to 0.33.0 we get a blue screen when playing back videos with 10-bit color / HDR. That's because `hwdec_ios` was erroring out at the `Format unsupported` error shown in the changelog for this PR.

I found this when digging https://github.com/mpv-player/mpv/issues/7846#issuecomment-647695198 and tried it and it works. I believe because we're doing our own rendering in the app (and Sergio's fancy rendering is working around the issues this check is supposed to avoid), we don't need to care about this check?

I've tested tone mapped playback and actual HDR playback (on TV and mobile) and with this change everything works as well as it did on 0.28 with 0.33.0

@rcombs interested in whether this makes any sense to you 🙈 😆 